### PR TITLE
Adding COSP MODIS variables and new CaseGroups

### DIFF
--- a/clouds/cosp_lib.py
+++ b/clouds/cosp_lib.py
@@ -14,13 +14,13 @@ from datetime import datetime, timedelta
 def cal_gbl_mean (ds, var):
     weights = np.cos(np.deg2rad(ds['lat']))
     weights.name = "weights"
-    gbl_mean_var = ds[var].weighted(weights).mean(dim=['lat', 'lon'])
+    gbl_mean_var = ds[var].weighted(weights).mean(dim=['lat', 'lon'],skipna=True)
     return  gbl_mean_var
 
 def monthly_mean (ds, var):
     weights = np.cos(np.deg2rad(ds['lat']))
     weights.name = "weights"
-    monthly_clim = ds[var].weighted(weights).mean(dim=['lat', 'lon']).groupby('time.month').mean(dim='time')
+    monthly_clim = ds[var].weighted(weights).mean(dim=['lat', 'lon'],skipna=True).groupby('time.month').mean(dim='time',skipna=True)
     return  monthly_clim
     
 # author: Huan.Guo@noaa.gov


### PR DESCRIPTION
Added a few more MODIS COSP variables that we will regularly look at and added reff_modis.  I also commented out the dora ID cases you were using and added three that I have used and others may find useful. This includes  a) a version of AM5 amip_cosp with a correction to the MODIS COSP effective radius (which impacts other variables. this has not been incorporated into am5_phys main yet but will be)  b) a similar version of AM5 amip_cosp but without the effective radius correction and c) a COSP run of AM4-MG2, all labeled accordingly

I also added skipna=true to a few of your cosp_lib.py functions. I can't entirely recall our conversation about this but I think we decided it made sense to add that but ultimately it did not make much of a difference.

